### PR TITLE
refactor(navigation): Restructure app navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@react-native-community/masked-view": "0.1.10",
         "@react-native-community/toolbar-android": "0.1.0-rc.1",
         "@react-navigation/bottom-tabs": "^5.0.5",
+        "@react-navigation/drawer": "^5.12.4",
         "@react-navigation/native": "^5.0.5",
         "@react-navigation/stack": "^5.0.5",
         "base-64": "^0.1.0",
@@ -32,8 +33,7 @@
         "react-native-webview": "11.0.0",
         "react-native-windows": "^0.61.15",
         "recompose": "^0.30.0"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.10.4",
@@ -2305,6 +2305,24 @@
         "query-string": "^6.13.5",
         "react-is": "^16.13.0",
         "use-subscription": "^1.4.0"
+      }
+    },
+    "node_modules/@react-navigation/drawer": {
+      "version": "5.12.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-5.12.4.tgz",
+      "integrity": "sha512-0O6OCTgCVnThx0XFsHd/48i6FeV7vxNvJYxeucantcdCwQMWJb46cVMsYGFYt49VwE8VX4Yg/KMZXMPfPxn7Pg==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "react-native-iphone-x-helper": "^1.3.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^5.0.5",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 1.0.0",
+        "react-native-reanimated": ">= 1.0.0",
+        "react-native-safe-area-context": ">= 0.6.0",
+        "react-native-screens": ">= 2.0.0-alpha.0 || >= 2.0.0-beta.0 || >= 2.0.0"
       }
     },
     "node_modules/@react-navigation/native": {
@@ -12447,6 +12465,15 @@
         "query-string": "^6.13.5",
         "react-is": "^16.13.0",
         "use-subscription": "^1.4.0"
+      }
+    },
+    "@react-navigation/drawer": {
+      "version": "5.12.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-5.12.4.tgz",
+      "integrity": "sha512-0O6OCTgCVnThx0XFsHd/48i6FeV7vxNvJYxeucantcdCwQMWJb46cVMsYGFYt49VwE8VX4Yg/KMZXMPfPxn7Pg==",
+      "requires": {
+        "color": "^3.1.3",
+        "react-native-iphone-x-helper": "^1.3.0"
       }
     },
     "@react-navigation/native": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-community/toolbar-android": "0.1.0-rc.1",
     "@react-navigation/bottom-tabs": "^5.0.5",
+    "@react-navigation/drawer": "^5.12.4",
     "@react-navigation/native": "^5.0.5",
     "@react-navigation/stack": "^5.0.5",
     "base-64": "^0.1.0",
@@ -36,6 +37,5 @@
     "react-native-windows": "^0.61.15",
     "recompose": "^0.30.0"
   },
-  "devDependencies": {},
   "private": true
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,19 +3,10 @@ import { registerRootComponent } from 'expo'
 import React from 'react'
 import { StatusBar, LogBox } from 'react-native'
 import { NavigationContainer } from '@react-navigation/native'
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
-
-// Import font awesome icons
-import Icon from 'react-native-vector-icons/FontAwesome5'
-
-// Import screens for navigation
-import { HomeScreen } from '../screens/Home'
-import { EventsScreen } from '../screens/Events'
-import { BlogScreen } from '../screens/Blog'
-import { MoreScreen } from '../screens/More'
 
 // Import Firebase Context Provider
 import Firebase, { FirebaseProvider } from '../../config/Firebase'
+import { RootStackScreen } from '../screens'
 
 // Fix firestore error - can be removed if issue is resolved in package
 import { decode, encode } from 'base-64'
@@ -28,51 +19,13 @@ if (!global.atob) {
 
 LogBox.ignoreLogs(['Setting a timer'])
 
-// Bottom tab navigator config
-const Tab = createBottomTabNavigator()
-
 // Create container for app with navigations
 const App = () => {
   return (
     <FirebaseProvider value={Firebase}>
-      <StatusBar barStyle='dark-content' />
+      <StatusBar />
       <NavigationContainer>
-        <Tab.Navigator
-          screenOptions={({ route }) => ({
-            tabBarIcon: ({ color, size }) => {
-              let iconName
-
-              if (route.name === 'Home') {
-                iconName = 'home'
-              } else if (route.name === 'Events') {
-                iconName = 'calendar'
-              } else if (route.name === 'Blog') {
-                iconName = 'blog'
-              } else if (route.name === 'More') {
-                iconName = 'ellipsis-h'
-              }
-
-              // You can return any component that you like here!
-              return (
-                <Icon
-                  name={iconName}
-                  size={size}
-                  color={color}
-                  style={{ textAlignVertical: 'center' }}
-                />
-              )
-            }
-          })}
-          tabBarOptions={{
-            activeTintColor: 'white',
-            activeBackgroundColor: '#3248a8'
-          }}
-        >
-          <Tab.Screen name='Home' component={HomeScreen} />
-          <Tab.Screen name='Events' component={EventsScreen} />
-          <Tab.Screen name='Blog' component={BlogScreen} />
-          <Tab.Screen name='More' component={MoreScreen} />
-        </Tab.Navigator>
+        <RootStackScreen />
       </NavigationContainer>
     </FirebaseProvider>
   )

--- a/src/screens/More/index.js
+++ b/src/screens/More/index.js
@@ -23,16 +23,14 @@ const donateButtonImage = require('./Donate_Button.jpg')
 const faqsButtonImage = require('./FAQs_Button.jpg')
 const contactButtonImage = require('./Contact_Button.jpg')
 
-class MoreScreenOptions extends React.Component {
+// Component for "more" screen in main navigation
+export class MoreScreen extends React.Component {
   render () {
     const { navigate } = this.props.navigation
     return (
       <>
         <SafeAreaView style={{ flex: 1 }}>
           <TouchableHighlight
-            onPress={() => {
-              navigate('Profile')
-            }}
             style={styles.button}
           >
             <ImageBackground
@@ -42,7 +40,7 @@ class MoreScreenOptions extends React.Component {
             >
               <View style={styles.view}>
                 <Text style={styles.text}>
-                  Profile
+                  {`Profile\nComing Soon!`}
                 </Text>
               </View>
             </ImageBackground>
@@ -103,23 +101,6 @@ class MoreScreenOptions extends React.Component {
           </TouchableHighlight>
         </SafeAreaView>
       </>
-    )
-  }
-}
-
-// Component for "more" screen in main navigation
-export class MoreScreen extends React.Component {
-  render () {
-    /* eslint-disable */
-    const { navigate } = this.props.navigation
-    return (
-      <Stack.Navigator>
-        <Stack.Screen name='More Options' component={MoreScreenOptions} />
-        <Stack.Screen name='Profile' component={ProfileScreen} />
-        <Stack.Screen name='FAQ' component={FAQScreen} />
-        <Stack.Screen name='Donate' component={DonateScreen} />
-        <Stack.Screen name='Contact' component={ContactScreen} />
-      </Stack.Navigator>
     )
   }
 }

--- a/src/screens/More/index.js
+++ b/src/screens/More/index.js
@@ -7,16 +7,8 @@ import {
   Text,
   SafeAreaView
 } from 'react-native'
-import { createStackNavigator } from '@react-navigation/stack'
-
-import ProfileScreen from './Profile'
-import { FAQScreen } from './FAQ'
-import { DonateScreen } from './Donate'
-import { ContactScreen } from './Contact'
 
 import { styles } from '../../styles'
-
-const Stack = createStackNavigator()
 
 const profileButtonImage = require('./Profile_Button.jpg')
 const donateButtonImage = require('./Donate_Button.jpg')
@@ -40,7 +32,7 @@ export class MoreScreen extends React.Component {
             >
               <View style={styles.view}>
                 <Text style={styles.text}>
-                  {`Profile\nComing Soon!`}
+                  {'Profile\nComing Soon!'}
                 </Text>
               </View>
             </ImageBackground>

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -8,7 +8,7 @@ import { EventsScreen } from './Events'
 import { BlogScreen } from './Blog'
 import { MoreScreen } from './More'
 
-import ProfileScreen from './More/Profile'
+// import ProfileScreen from './More/Profile'
 import { FAQScreen } from './More/FAQ'
 import { DonateScreen } from './More/Donate'
 import { ContactScreen } from './More/Contact'
@@ -58,21 +58,21 @@ function TabsScreen () {
   )
 }
 
-function MainStackScreen() {
+function MainStackScreen () {
   return (
     <MainStack.Navigator>
-      <MainStack.Screen name="Tab" component={TabsScreen} options={{ headerShown: false }} />
+      <MainStack.Screen name='Tab' component={TabsScreen} options={{ headerShown: false }} />
       <MainStack.Screen name='FAQ' component={FAQScreen} />
       <MainStack.Screen name='Donate' component={DonateScreen} />
       <MainStack.Screen name='Contact' component={ContactScreen} />
     </MainStack.Navigator>
-  );
+  )
 }
 
 export function RootStackScreen () {
   return (
-    <RootStack.Navigator mode="modal">
-      <RootStack.Screen name="Main" component={MainStackScreen} options={{ headerShown: false }} />
+    <RootStack.Navigator mode='modal'>
+      <RootStack.Screen name='Main' component={MainStackScreen} options={{ headerShown: false }} />
     </RootStack.Navigator>
   )
 }

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import { createStackNavigator } from '@react-navigation/stack'
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
+import Icon from 'react-native-vector-icons/FontAwesome5'
+
+import { HomeScreen } from './Home'
+import { EventsScreen } from './Events'
+import { BlogScreen } from './Blog'
+import { MoreScreen } from './More'
+
+import ProfileScreen from './More/Profile'
+import { FAQScreen } from './More/FAQ'
+import { DonateScreen } from './More/Donate'
+import { ContactScreen } from './More/Contact'
+
+const RootStack = createStackNavigator()
+const MainStack = createStackNavigator()
+const Tabs = createBottomTabNavigator()
+
+function TabsScreen () {
+  return (
+    <Tabs.Navigator
+      screenOptions={({ route }) => ({
+        tabBarIcon: ({ color, size }) => {
+          let iconName
+
+          if (route.name === 'Home') {
+            iconName = 'home'
+          } else if (route.name === 'Events') {
+            iconName = 'calendar'
+          } else if (route.name === 'Blog') {
+            iconName = 'blog'
+          } else if (route.name === 'More') {
+            iconName = 'ellipsis-h'
+          }
+
+          // You can return any component that you like here!
+          return (
+            <Icon
+              name={iconName}
+              size={size}
+              color={color}
+              style={{ textAlignVertical: 'center' }}
+            />
+          )
+        }
+      })}
+      tabBarOptions={{
+        activeTintColor: 'white',
+        activeBackgroundColor: '#3248a8'
+      }}
+    >
+      <Tabs.Screen name='Home' component={HomeScreen} />
+      <Tabs.Screen name='Events' component={EventsScreen} />
+      <Tabs.Screen name='Blog' component={BlogScreen} />
+      <Tabs.Screen name='More' component={MoreScreen} />
+    </Tabs.Navigator>
+  )
+}
+
+function MainStackScreen() {
+  return (
+    <MainStack.Navigator>
+      <MainStack.Screen name="Tab" component={TabsScreen} options={{ headerShown: false }} />
+      <MainStack.Screen name='FAQ' component={FAQScreen} />
+      <MainStack.Screen name='Donate' component={DonateScreen} />
+      <MainStack.Screen name='Contact' component={ContactScreen} />
+    </MainStack.Navigator>
+  );
+}
+
+export function RootStackScreen () {
+  return (
+    <RootStack.Navigator mode="modal">
+      <RootStack.Screen name="Main" component={MainStackScreen} options={{ headerShown: false }} />
+    </RootStack.Navigator>
+  )
+}

--- a/src/styles.js
+++ b/src/styles.js
@@ -23,11 +23,12 @@ export const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'rgba(0,0,0,0.5)',
-    flex: 1
+    flex: 1,
+    borderRadius: 10,
   },
   text: {
     color: 'white',
     fontWeight: 'bold',
-    fontSize: 50
+    fontSize: 50,
   }
 })

--- a/src/styles.js
+++ b/src/styles.js
@@ -24,11 +24,11 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: 'rgba(0,0,0,0.5)',
     flex: 1,
-    borderRadius: 10,
+    borderRadius: 10
   },
   text: {
     color: 'white',
     fontWeight: 'bold',
-    fontSize: 50,
+    fontSize: 50
   }
 })


### PR DESCRIPTION
In order to create full screen modals and stacks that are not directly nested from the tab navigator, I had to move our navigation structure to `screens/index.js`. The structure is as follows:

* RootStackScreen - The modal stack navigator. Anything at this level will appear as a full-screen modal.
  - MainStackScreen - The main stack navigator. This holds any 'pop-up' screens that would use a back button.
    * TabsScreen - The bottom tabs navigator that you know and love.
      - HomeScreen
      - EventsScreen
      - BlogScreen
      - MoreScreen
    * FAQScreen
    * DonateScreen
    * ContactScreen

When we are ready to add the Profile page and detailed event page, they will go in as a child of the MainStackScreen. The initial login page when a user first loads the app and the error page will go as children to RootStackScreen so they are shown as a full screen modal without any navigation history. 

I also fixed the more page buttons and removed the profile button's route since this will not be present in 1.0.0.